### PR TITLE
Interview list wrapper + alt text and CSS

### DIFF
--- a/docassemble/mlhframework/data/questions/interview_list.yml
+++ b/docassemble/mlhframework/data/questions/interview_list.yml
@@ -1,0 +1,4 @@
+---
+include:
+  - docassemble.AssemblyLine:interview_list.yml
+  - mlh_interview_framework.yml

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -14,7 +14,9 @@ features:
 objects:
   - al_logo: DAStaticFile.using(filename="mlh_logo_M_only_40_px.png")
   - court_list: ALCourtLoader.using(file_name='michigan_court_info.xlsx')
-
+---
+code: |
+  al_logo.alt_text = "Michigan Legal Help Terms of Use"
 ---
 code: |
   # These block defines Assembly Line-level variables and MLH Organization-level variables

--- a/docassemble/mlhframework/data/static/mlh_framework_theme.css
+++ b/docassemble/mlhframework/data/static/mlh_framework_theme.css
@@ -6,13 +6,15 @@
   background-color: #ccc
 }
 
+/*
 .al-logo {
-  #background-color: #005A7C
+  background-color: #005A7C;
   background-color: #fff;
 }
+*/
 
 body {
-  background-color: #fefefe
+  background-color: #fefefe;
 }
 
 .da-review > * > p:first-of-type {


### PR DESCRIPTION
Fix #9

Really wasn't anything else to add to the interview list wrapper, just to include the `interview_list.yml` and `mlh_interview_framework.yml`.

I also added alt text to the logo (we can always change it later, but it's a good placeholder to say where the link will lead to), and corrected some CSS issues, that just happened to be working, but we really being ignored. `#` makes a comment in python, but in CSS you have to wrap everything in the comment with `/*` and `*/`. 🤷🏻 

Image of what it looks like with `debug: True`

![Screenshot from 2023-10-10 13-33-38](https://github.com/mplp/docassemble-mlhframework/assets/6252212/143068a2-feb6-47ff-a6f4-ee1028fafc2a)
