### PR TITLE
Small cleanups in the interview framework

### DIFF
--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -36,14 +36,11 @@ code: |
   # This will get the docassemble-level metadata short title
   MLH_interview_short_title = all_variables(special='metadata').get('short title')
   MLH_interview_title = all_variables(special='metadata').get('title')
-    # This will get the AssemblyLine-level metadata short title
-    #MLH_interview_title = interview_metadata["main_interview_key"]["title"]
-    #MLH_interview_short_title = interview_metadata["main_interview_key"]["short title"]
 
 ---
 code: |
   # This block contains MLH Organization-level variables that will vary from tool to tool.
-  # These are the organzation defaults. 
+  # These are the organization defaults.
   # Copy this block to an individual interview yml file and override as needed. 
   github_repo_name = "docassemble-General"  # default github repo
   MLH_instructions_included = False  # are instructions generated with the form(s)/letter(s)?
@@ -113,8 +110,8 @@ code: |
   MLH_intro_navigation
   MLH_intro_saving_answers
   MLH_intro_time
-  if MLH_intro_agree_no_pii == False :
-    agree_no_pii_exit
+  if MLH_intro_agree_no_pii == False:
+    MLH_intro_agree_no_pii_exit
   # This line exists so that these standard intro pages can be included from another
   # interview just by referencing this variable.
   MLH_standard_intro_pages = True
@@ -184,13 +181,11 @@ subquestion: |
   
   To go back to a tool you started before, make sure you are logged in. Then go to the menu at the top of the screen and select “My Interviews.”
 continue button field: MLH_intro_saving_answers
-
 ---
 id: MLH intro PII
-mandatory: false
-question: "Personal Identifying Information"
+question: Private Information
 subquestion: |
-  To protect privacy, you cannot include personal identifying information in public documents that are filed in court. Personal identifying information includes:
+  To protect privacy, you **cannot** include personal identifying information in public documents that are filed in court. Personal identifying information includes:
   
   * Date of birth
   * Social security or national identification number
@@ -198,27 +193,22 @@ subquestion: |
   * Passport number
   * Financial account numbers
 
-  **If a question doesn't specifically ask for personal identifying information, do not include it in your answers.** When this information is necessary, this tool will specifically ask for the information and it will go on a separate non-public form that you will file along with the other documents. This DIY tool will automatically produce that form if you need it.
-
-  Do you understand that you should not enter any personal identifying information unless this tool specifically asks for it?
-#fields:
-#  - no label: agree_no_pii
-#    datatype: yesnoradio
-field: MLH_intro_agree_no_pii
-buttons:
-  - "Yes": True
-  - "No": False
+  **If a question doesn't specifically ask for personal identifying information, do not include it in your answers.** 
+  When this information is necessary, this tool will specifically ask for the information and it will go on a separate non-public form that you will file along with the other documents. 
+  This DIY tool will automatically produce that form if you need it.
+fields:
+  - Do you understand you should not enter any personal identifying information unless this tool specifically asks for it?: MLH_intro_agree_no_pii
+    datatype: yesnoradio
 ---
-# event: agree_no_pii_exit
+id: Agree no PII exit
 question: You cannot use this tool. 
 subquestion: |
   You cannot continue with this tool unless you understand that you should not enter any personal identifying information that the tool does not specifically ask for.
   
-  If you made a mistake, click the **< ${ MLH_back_button_label }** button to change your answer. Otherwise, click 'Exit'. ${MLH_GUIDE_FULL}
+  If you made a mistake, click the **< ${ MLH_back_button_label }** button to change your answer. Otherwise, click 'Exit' to return to Michigan Legal Help.
 buttons:
   - Exit: exit
-continue button field: agree_no_pii_exit
-
+event: MLH_intro_agree_no_pii_exit
 # # # # # # # # # # # # # # # # Standard Outro Pages # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # Standard Outro Pages # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # Standard Outro Pages # # # # # # # # # # # # # # # #


### PR DESCRIPTION
* Updated the PII question to how it looks in the SimpMotion, and made the question easier to see when answering
    * from what I can tell, this is still only in the framework, so changing the variable name to match should be good too
* Made the PII kickout screen not a continue button, so people cannot continue the interview. Matches what I've seen in LHI and have used in other interviews I've written
* fixed a typo
* got rid of commented older ways of getting titles that weren't going to work. (I tend to remove unused code, let me know if I get too over-zealous with it though).