### PR TITLE
Adds default address that accept international addrs

### DIFF
--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -488,3 +488,23 @@ fields:
         defined("users[0].address.address")
   - code: |
       users[i].address.address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE, show_country=True)
+---
+generic object: ALAddress
+template: x.address_label
+content: |
+  Street Address or PO Box
+---
+generic object: ALAddress
+template: x.unit_label
+content: |
+  Apartment, suite, etc
+---
+generic object: ALAddress
+template: x.state_or_province_label
+content: |
+  State or Province
+---
+generic object: ALAddress
+template: x.postal_code_label
+content: |
+  Zip or Postal Code

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -431,3 +431,60 @@ continue button field: court_info_display
 # # # # # # # # # # # # # # # Court Loader - End # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # Court Loader - End # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # Court Loader - End # # # # # # # # # # # # # # #
+---
+sets:
+  - x.address.address
+  - x.address.city
+  - x.address.zip
+  - x.address.unit
+  - x.address.state
+  - x.address.country
+id: persons address
+generic object: ALIndividual
+question: |
+  What is ${ x.possessive('address') }?
+fields:
+  - code: |
+      x.address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE, show_country=True)
+---
+id: your address
+sets:
+  - users[0].address.address
+  - users[0].address.city
+  - users[0].address.zip
+  - users[0].address.unit
+  - users[0].address.state
+  - users[0].address.country
+question: |
+  What is your address?
+subquestion: |
+  Use an address where you can be contacted.
+fields:
+  - code: |
+      users[0].address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE, show_country=True)
+---
+id: user i's address
+sets:
+   - users[i].address.address
+   - users[i].address.city
+   - users[i].address.zip
+   - users[i].address.unit
+   - users[i].address.state
+   - users[i].address.country
+question: |
+  What is ${ users[i] }'s address?
+fields:
+  - Same as your address: users[i].address
+    datatype: object_radio
+    choices:
+      - users[0].address if defined("users[0].address.address") else None
+    object labeler: |
+      lambda y: y.on_one_line()
+    none of the above: |
+      Somewhere else
+    disable others: True
+    show if:
+      code: |
+        defined("users[0].address.address")
+  - code: |
+      users[i].address.address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE, show_country=True)


### PR DESCRIPTION
Fixes https://github.com/mplp/docassemble-MLHMotionRegardingChildSupport/issues/6.

Some examples of what the address questions look like now, not too much different now, just that there's a country input, and the state input is a text field, not a dropdown. See https://github.com/SuffolkLITLab/docassemble-AssemblyLine/pull/794 for

![Screenshot from 2023-11-24 09-55-00](https://github.com/mplp/docassemble-mlhframework/assets/6252212/8ca7595d-eb0d-4567-83f9-0c045f6380f1)

![Screenshot from 2023-11-24 09-54-39](https://github.com/mplp/docassemble-mlhframework/assets/6252212/8c8a1df9-ae6f-4629-94c4-d72827f8e20d)
 some reasons for that choice.

