### PR TITLE
Consider Dark Mode

### DIFF
--- a/docassemble/mlhframework/data/static/mlh_framework_theme.css
+++ b/docassemble/mlhframework/data/static/mlh_framework_theme.css
@@ -28,11 +28,14 @@
 
 /* Styles for the entire page. */
 body {
-  background-color: #fefefe;
-  color: black;
   font-family: "Work Sans", "Helvetica", "Arial", sans-serif;
   font-size:1.125rem;
   line-height: 1.8;
+}
+
+[data-bs-theme=light] body {
+  background-color: #fefefe;
+  color: black;
 }
 
 /* These only happen on desktop, not mobile. */
@@ -62,8 +65,12 @@ body {
   }
 }
 
-.da-review > * > p:first-of-type {
+[data-bs-theme=light] .da-review > * > p:first-of-type {
   background-color: #ddd
+}
+
+[data-bs-theme=dark] .da-review.bg-light {
+  background-color: rgba(0, 0, 0, 0) !important;
 }
 
 .bg-dark.navbar {
@@ -77,7 +84,35 @@ body {
   font-size: 0.98rem;
 }
 
+/* Manually use browser focus-visible, since bootstrap focus is the same color
+  as the top bar */
+.navbar .nav-link:focus-visible {
+  outline: solid 1px;
+}
+
 /* Manually override hardcoded styles from Assembly Line. */
-footer a {
+[data-bs-theme=light] footer a {
   color: #005A7c;
+}
+
+[data-bs-theme=dark] footer a {
+  color: #5badcb
+}
+
+/* An upstream fix, with radio buttons and checkboxes. See https://github.com/jhpyle/docassemble/pull/718 */
+[data-bs-theme=dark] .btn-light.dalabelauty {
+  --bs-btn-color: #fff;
+  --bs-btn-bg: #212529;
+  --bs-btn-border-color: #212529;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-hover-bg: #424649;
+  --bs-btn-hover-border-color: #373b3e;
+  --bs-btn-focus-shadow-rgb: 66, 70, 73;
+  --bs-btn-active-color: #fff;
+  --bs-btn-active-bg: #4d5154;
+  --bs-btn-active-border-color: #373b3e;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #fff;
+  --bs-btn-disabled-bg: #212529;
+  --bs-btn-disabled-border-color: #212529;
 }


### PR DESCRIPTION
Docassemble gives us the ability to have a light-mode and dark-mode of our site, which we can customize with some extra CSS.

We have a few options regarding dark mode:

1. adhere to user's preference for light/dark mode (usually set through the browser or OS, https://support.google.com/chrome/answer/9275525)
    * pros: more accessible, gives a better experience to users who have difficulty reading text on a white background
    * cons: we have to be sure to test style changes, images, and colors on multiple themes. At the moment, just light and dark (but it might increase if we also do `prefers-contrast`, see bottom for more notes).
2. turn it off entirely on the server. `auto color scheme: False` in the config will do that, and keep everyone on light mode.
    * pros: simple, we can set this and forget about it
    * cons: not as accessible, will likely be a feature that comes up again in audits or user testing.

If we opt for 2, this PR fixes some of our style issues in dark mode. Used the default dark mode colors from bootstrap, making the primary color have enough contrast. If we opt for 1, I suggest that we merge this anyway (it won't affect light mode), and just set the config on our servers to include `auto color scheme: False`.

I just wanted to confirming that this was possible to fix. I'm okay with either of these changes (although I want to look into [Window's high-contrast mode](https://www.smashingmagazine.com/2022/06/guide-windows-high-contrast-mode/), a similar feature with a much stronger accessibility use case IMO, but I don't have a Window's computer to test with at the moment).