### PR TITLE
Remove unused exit link from default screen parts

### DIFF
--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -85,7 +85,6 @@ default screen parts:
   # based on desired label, (i.e. "Back" or "Undo")
   #corner back button label: Back  
 
-  exit link: https://michiganlegalhelp.org/guide-to-legal-help
   exit url: https://michiganlegalhelp.org
   # The below option customizes what's to the left of the menu / user's info 
   #navigation bar html: <li class="nav-item"><a class="nav-link" href="/some_link">Labell</a></li>


### PR DESCRIPTION
[Exit link](https://docassemble.org/docs/initial.html#exit%20link) defines the behavior of the top right exit button when `show login` is False, something that we haven't done, and I don't think we will do for our interviews.

Given we had already incorrectly set it to a URL, and I got confused and made incorrect comments on three different issues because it's a strangely described feature, IMO we should just remove it. Not urgent though.