### PR TITLE
Remove redundant alt text on logo

### DIFF
--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -12,7 +12,7 @@ features:
     - https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&amp;family=Work+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&amp;display=swap
 ---
 objects:
-  - al_logo: DAStaticFile.using(filename="mlh_logo_M_only_40_px.png", alt_text="Michigan Legal Help Logo")
+  - al_logo: DAStaticFile.using(filename="mlh_logo_M_only_40_px.png", alt_text="")
   - court_list: ALCourtLoader.using(file_name='michigan_court_info.xlsx')
   - image_case_number: |
       DAStaticFile.using(
@@ -20,7 +20,7 @@ objects:
         alt=word("A court form. The case number, 01-234 DM, is circled in the top right"))
 ---
 code: |
-  al_logo.alt_text = "Michigan Legal Help Logo"
+  al_logo.alt_text = ""
 ---
 code: |
   # These block defines Assembly Line-level variables and MLH Organization-level variables


### PR DESCRIPTION
A change suggested by an accessibility audit on another Assembly Line project.

Related to https://github.com/SuffolkLITLab/docassemble-AssemblyLine/issues/795