### PR TITLE
Easy-to-fix Style suggestions from Feedback

### DIFF
--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -216,7 +216,7 @@ subquestion: |
   % if device().is_mobile:
   :bars:
   % endif
-  **menu at the top of the screen** and tap "Sign up or sign in to save answers".
+  **menu at the top of the screen** and tap "Sign in or sign up to save answers".
   
   To go back to saved answers, make sure you are logged in. Then go to the menu at the top of the screen and select “My Interviews.”
 continue button field: MLH_intro_saving_answers
@@ -364,7 +364,7 @@ subquestion: |
   % if device().is_mobile:
   :bars:
   % endif
-  menu at the top of the screen and tap "Sign up or sign in to save answers".
+  menu at the top of the screen and tap "Sign in or sign up to save answers".
 
   To go back to saved answers, make sure you are logged in. Then go to the menu at the top of the screen and select “My Interviews.”
 continue button field: MLH_outro_saving_answers

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -92,7 +92,6 @@ default screen parts:
   #pre: This is the pre screen part.
   #submit: This is the submit screen part.
   # post: Provided by [Michigan Legal Help](https://michiganlegalhelp.org).
-  #under: This is the under screen part.
   #right: This is the right screen part.
   global footer: This is the footer part.
   main page footer: This is the main footer.
@@ -105,6 +104,10 @@ default screen parts:
         <span class="title-row-1">${ all_variables(special='metadata').get('short title','').rstrip() }</span>
       </span>
     </span>
+  under: |
+    % if not user_logged_in():
+    [:key: Sign in](${url_of('login', next=interview_url())}) or [sign up](${url_of('register', next=interview_url())}) to return later
+    % endif
   footer: |
     [:share-alt-square: Share](${ url_ask([{'undefine': ['al_sharing_type','al_how_share_link']}, 'al_share_form_screen', {'recompute': ['al_did_share_form']}, 'al_share_results']) }){:target="_blank"}
     [:info-circle: About](${ url_action('about_this_interview') }){:target="_blank"}
@@ -209,7 +212,11 @@ question: |
 subquestion: |
   If you can't finish now or need to get more information, you can save your work at any time. This lets you return later and finish, or go back and change any of your answers.
 
-  Go to the **menu at the top of the screen** and click "Sign in or sign up to save answers".
+  Below the **Continue** button, tap "Sign in" if you have an account or "Sign up" to make one. You can also go to the
+  % if device().is_mobile:
+  :bars:
+  % endif
+  **menu at the top of the screen** and tap "Sign up or sign in to save answers".
   
   To go back to saved answers, make sure you are logged in. Then go to the menu at the top of the screen and select “My Interviews.”
 continue button field: MLH_intro_saving_answers
@@ -357,7 +364,11 @@ question: |
 subquestion: |
   You can save your answers so that you can come back to this tool later. This will allow you to make changes to your ${ MLH_form_type } without starting over.
 
-  Go to the menu at the top of the screen and click "Sign up or sign in to save answers".
+  Below the **Continue** button, tap "Sign in" if you have an account or "Sign up" to make one. You can also go to the
+  % if device().is_mobile:
+  :bars:
+  % endif
+  menu at the top of the screen and tap "Sign up or sign in to save answers".
 
   To go back to saved answers, make sure you are logged in. Then go to the menu at the top of the screen and select “My Interviews.”
 continue button field: MLH_outro_saving_answers

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -350,12 +350,8 @@ content: |
   ${ MLH_case_type_language }
 ---
 if: user_logged_in()
-id: MLH outro saving answers logged in
-question: |
-  Your answers have been saved
-subquestion: |
-  You can come back to this tool later and can make changes to your ${ MLH_form_type } without starting over.
-continue button field: MLH_outro_saving_answers
+code: |
+  MLH_outro_saving_answers = True
 ---
 if: not user_logged_in()
 id: MLH outro saving answers logged out

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -106,7 +106,7 @@ default screen parts:
     </span>
   under: |
     % if not user_logged_in():
-    [:key: Sign in](${url_of('login', next=interview_url())}) or [sign up](${url_of('register', next=interview_url())}) to return later
+    [:key: Sign in](${url_of('login', next=interview_url())}) or [sign up](${url_of('register', next=interview_url())}) to save your progress.
     % endif
   footer: |
     [:share-alt-square: Share](${ url_ask([{'undefine': ['al_sharing_type','al_how_share_link']}, 'al_share_form_screen', {'recompute': ['al_did_share_form']}, 'al_share_results']) }){:target="_blank"}

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -91,7 +91,7 @@ default screen parts:
 
   #pre: This is the pre screen part.
   #submit: This is the submit screen part.
-  post: Provided by [Michigan Legal Help](https://michiganlegalhelp.org).
+  # post: Provided by [Michigan Legal Help](https://michiganlegalhelp.org).
   #under: This is the under screen part.
   #right: This is the right screen part.
   global footer: This is the footer part.

--- a/docassemble/mlhframework/data/static/mlh_framework_theme.css
+++ b/docassemble/mlhframework/data/static/mlh_framework_theme.css
@@ -110,12 +110,17 @@ body {
   outline: solid 1px;
 }
 
+.daundertext {
+  padding: 1rem 0.75rem;
+}
+
+
 /* Manually override hardcoded styles from Assembly Line. */
 footer a {
   color: #005A7c;
 }
 
-footer {
+footer, .daundertext {
   font-size: 1rem;
 }
 

--- a/docassemble/mlhframework/data/static/mlh_framework_theme.css
+++ b/docassemble/mlhframework/data/static/mlh_framework_theme.css
@@ -115,6 +115,14 @@ footer a {
   color: #005A7c;
 }
 
+footer {
+  font-size: 1rem;
+}
+
+footer a {
+  padding-left: 1.6rem;
+}
+
 [data-bs-theme=dark] footer a {
   color: #5badcb
 }


### PR DESCRIPTION
Went for the low hanging fixes first. Will get to the more involved ones next.

Suggestion for testing on mobile: in firefox you can press ctrl-shift-m to automatically size your browser to a mobile device (and also acts like it as well, so docassemble thinks that you're a phone). Chrome has a similar thing, but you have to open dev tools and click on "Responsive" above the window to select the phone size.

This PR fixes the following:

* Makes share/about/feedback in the footer a bit smaller so it doesn't overflow narrow screens. Did this by making the text smaller and decreasing the padding between each item 

   Before:
   ![Screenshot from 2023-12-22 11-12-12](https://github.com/mplp/docassemble-mlhframework/assets/6252212/ee07b06b-bb43-4795-982c-fda247dc56d8)
   
   After:
   ![Screenshot from 2023-12-22 11-12-48](https://github.com/mplp/docassemble-mlhframework/assets/6252212/fa3bd07f-ffb2-455b-b884-af0c981f906e)

* Removed "Provided by Michigan Legal Help" from the bottom of the page

   Before:
   ![Screenshot from 2023-12-22 11-43-35](https://github.com/mplp/docassemble-mlhframework/assets/6252212/df1f1ccd-fd1c-44dd-b158-5f7d830434ce)

   After:
   ![Screenshot from 2023-12-22 11-44-25](https://github.com/mplp/docassemble-mlhframework/assets/6252212/c6827682-e5e4-4ab8-bc60-c1a20ef96f37)


* Adjusted the "Sign in" text below the continue button when logged out.
   * Used a key icon instead of the "sign-in" one, to avoid the extra confusing arrow
   * Updated language to "Sign in or sign up" to match the menu option on the same page, and to be a bit shorter. **Would appreciate feedback on this version of the text**. "Register" is still used internally and on a few other pages, but I'm going to take a look at how to customize the "Register" page anyway for #60. 
   * Added padding to left-align with the undo button and move it a bit further away from the buttons as well.
   
   Before:
   ![Screenshot from 2023-12-22 11-49-40](https://github.com/mplp/docassemble-mlhframework/assets/6252212/b76e741d-87ef-4295-bcf6-b9e42fc1340b)

   After:
   ![Screenshot from 2023-12-22 11-49-48](https://github.com/mplp/docassemble-mlhframework/assets/6252212/f5a4d5c9-ec6d-47c1-9a8b-77de43ab3664)

* Reference "sign in" links under the continue button in the "Save your answers" screens. Also adds the menu icon if it's being used (on mobile devices). **Would also appreciate feedback on this version of the text.**

   Before:
   ![Screenshot from 2023-12-22 11-53-41](https://github.com/mplp/docassemble-mlhframework/assets/6252212/58784691-aa9f-47fb-bc51-6593760a5331)

   After: 
   ![Screenshot from 2023-12-22 11-53-37](https://github.com/mplp/docassemble-mlhframework/assets/6252212/7afeb869-64de-4fdb-8b0c-c2921390a97d)

* Hides the outro saving answers screen if already logged. Tested this on the Landlord interview