### PR TITLE
Improve nav bar sizes on mobile screens

### DIFF
--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -96,6 +96,15 @@ default screen parts:
   #right: This is the right screen part.
   global footer: This is the footer part.
   main page footer: This is the main footer.
+  short logo: |
+    <span class="title-container">
+      <span class="al-logo">
+        <img src="${ al_logo.url_for() }" alt="${ al_logo.alt_text }"/>
+      </span>
+      <span class="al-title-short">
+        <span class="title-row-1">${ all_variables(special='metadata').get('short title','').rstrip() }</span>
+      </span>
+    </span>
   footer: |
     [:share-alt-square: Share](${ url_ask([{'undefine': ['al_sharing_type','al_how_share_link']}, 'al_share_form_screen', {'recompute': ['al_did_share_form']}, 'al_share_results']) }){:target="_blank"}
     [:info-circle: About](${ url_action('about_this_interview') }){:target="_blank"}

--- a/docassemble/mlhframework/data/static/custom_bootstrap.css
+++ b/docassemble/mlhframework/data/static/custom_bootstrap.css
@@ -3876,8 +3876,8 @@ textarea.form-control-lg {
   --bs-navbar-brand-color: rgba(var(--bs-emphasis-color-rgb), 1);
   --bs-navbar-brand-hover-color: rgba(var(--bs-emphasis-color-rgb), 1);
   --bs-navbar-nav-link-padding-x: 0.5rem;
-  --bs-navbar-toggler-padding-y: 0.25rem;
-  --bs-navbar-toggler-padding-x: 0.75rem;
+  --bs-navbar-toggler-padding-y: 0.167rem;
+  --bs-navbar-toggler-padding-x: 0.5rem;
   --bs-navbar-toggler-font-size: 1.25rem;
   --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2833, 37, 41, 0.75%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
   --bs-navbar-toggler-border-color: rgba(var(--bs-emphasis-color-rgb), 0.15);
@@ -11859,4 +11859,4 @@ textarea.form-control-lg {
   }
 }
 
-/*# sourceMappingURL=2b40eb1d-7193-4c0c-89eb-fc0f16d82aec.css.map */
+/*# sourceMappingURL=41d56531-0115-4586-bf4d-44249a345a9c.css.map */

--- a/docassemble/mlhframework/data/static/custom_bootstrap.scss
+++ b/docassemble/mlhframework/data/static/custom_bootstrap.scss
@@ -17,4 +17,8 @@ $navbar-dark-hover-color: rgba($white, 1.0);
 
 $body-secondary-color: rgba($gray-900, 0.85);
 
+/* Makes the menu toggle button slightly smaller on small screens. */
+$navbar-toggler-padding-x: 0.5rem;
+$navbar-toggler-padding-y: 0.167rem;
+
 @import "bootstrap";

--- a/docassemble/mlhframework/data/static/mlh_framework_theme.css
+++ b/docassemble/mlhframework/data/static/mlh_framework_theme.css
@@ -16,8 +16,13 @@
 /* Make the nav bar contents (title and logo) smaller on narrow screens, and
    clip contents instead of letting them push menu button to the next line */
 @media only screen and (max-width: 800px) {
-  .al-title, .al-logo {
+  .al-logo {
     font-size: 60%;
+  }
+
+  .al-title-short {
+    font-size: 100%;
+    font-weight: normal;
   }
 
   .al-logo img {
@@ -35,8 +40,10 @@
 }
 
 /* Fonts and font sizes taken from https://michiganlegalhelp.org/guide-to-legal-help. */
-.al-title {
+.al-title-short {
+  display: inline;
   font-family: "Poppins",times,"Times New Roman",serif;
+  line-height: 1em;
 }
 
 /* Styles for the entire page. */

--- a/docassemble/mlhframework/data/static/mlh_framework_theme.css
+++ b/docassemble/mlhframework/data/static/mlh_framework_theme.css
@@ -9,15 +9,28 @@
 /* Makes the logo have a white background with rounded corners. */
 .al-logo {
   background-color: #fff;
-  padding: 5px;
   border-radius: 10px;
   padding: 3px;
 }
 
-/* This overrides AL styles that set font-size to 60% on small screens. Big titles look fine. */
+/* Make the nav bar contents (title and logo) smaller on narrow screens, and
+   clip contents instead of letting them push menu button to the next line */
 @media only screen and (max-width: 800px) {
   .al-title, .al-logo {
-    font-size: 100%;
+    font-size: 60%;
+  }
+
+  .al-logo img {
+    max-height: 25px;
+  }
+
+  .al-logo {
+    border-radius: 8px;
+    padding: 2px;
+  }
+
+  #dapagetitle {
+    max-width: calc(100vw - 90px);
   }
 }
 


### PR DESCRIPTION
Before:

![Screenshot from 2023-12-22 12-06-26](https://github.com/mplp/docassemble-mlhframework/assets/6252212/3b433bd8-6c36-4a28-b775-bf780727acb6)

After:

![Screenshot from 2023-12-22 12-06-32](https://github.com/mplp/docassemble-mlhframework/assets/6252212/28d4ed40-ca4c-4303-b77d-7c73d534d0b5)

Example of clipping if the interview's `short title` is too long for the screen:

![Screenshot from 2023-12-22 12-42-42](https://github.com/mplp/docassemble-mlhframework/assets/6252212/db186f12-596e-4cdf-9eaa-ccf56afa2352)

User feedback screen is fixed too:

![Screenshot from 2023-12-22 13-30-16](https://github.com/mplp/docassemble-mlhframework/assets/6252212/0ba91603-ad9c-4180-ac28-6c1e51f3520b)


Happy to tweak whatever we want for balance.

Fix #57.