### PR TITLE
Translate system phrases to avoid "register"

### DIFF
--- a/docassemble/mlhframework/data/sources/us-words.yml
+++ b/docassemble/mlhframework/data/sources/us-words.yml
@@ -1,0 +1,3 @@
+en:
+  "Already registered?": "Already have an account?"
+  "Register": "Sign up"


### PR DESCRIPTION
Prefering sign up as well, a bit simpler language.

With these config changes, fix #60:

```yml
words:
  - docassemble.mlhframework:data/sources/us-words.yml
  - docassemble.base...
...
register page heading: Sign up
register page title: Sign up
register page tab title: Sign up
register page submit: |
  Your password must be 6 characters long with 1 lowercase, 1 uppercase, and 1 number.
```