### PR TITLE
Correct alt_text typo

### DIFF
--- a/docassemble/mlhframework/data/questions/mlh_feedback.yml
+++ b/docassemble/mlhframework/data/questions/mlh_feedback.yml
@@ -19,7 +19,7 @@ objects:
   - image_github_image_paste: |
       DAStaticFile.using(
         filename="github_image_paste.png",
-        alt=word("Copy and paste an image or screenshot right into a GitHub Comment"))
+        alt_text=word("Copy and paste an image or screenshot right into a GitHub Comment"))
 
 ---
 if: |

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -17,7 +17,7 @@ objects:
   - image_case_number: |
       DAStaticFile.using(
         filename="case_number.jpg",
-        alt=word("A court form. The case number, 01-234 DM, is circled in the top right"))
+        alt_text=word("A court form. The case number, 01-234 DM, is circled in the top right"))
 ---
 code: |
   al_logo.alt_text = ""


### PR DESCRIPTION
I had been using the wrong attribute in docassemble (`alt` instead of `alt_text`), so alt text was not appearing properly. This fixes the mistake.