### PR TITLE
Made signin button on desktop bigger

### DIFF
--- a/docassemble/mlhframework/data/static/mlh_framework_theme.css
+++ b/docassemble/mlhframework/data/static/mlh_framework_theme.css
@@ -212,3 +212,8 @@ footer a {
 .danavdiv a:not(.daclickable) {
   color: var(--bs-body-color);
 }
+
+/* Make "Sign in" button on desktop bigger: https://github.com/mplp/docassemble-mlhframework/issues/87 */
+#danavbar-collapse a.btn-primary[href="/user/sign-in"] {
+  --bs-btn-font-size: 1.125rem;
+}


### PR DESCRIPTION
Now matches the "Sign up" link directly next to it. Should be very scoped, and shouldn't affect anything else (the mobile dropdown looks the same for me).

Fix #87.

![Screenshot from 2024-03-24 11-21-11](https://github.com/mplp/docassemble-mlhframework/assets/6252212/d60cc936-c41a-402a-a663-a9a2dbea3d51)
