### PR TITLE
remove MLH_outro_download_forms as unnecessary

### DIFF
--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -277,7 +277,6 @@ code: |
     if MLH_esign:
       signature_date
   MLH_outro_saving_answers
-  MLH_outro_download_forms
   MLH_standard_outro_pages = True
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -370,34 +369,6 @@ subquestion: |
 
   To go back to saved answers, make sure you are logged in. Then go to the menu at the top of the screen and select “My Interviews.”
 continue button field: MLH_outro_saving_answers
----
-id: MLH outro download forms
-question: |
-  Download Your ${ MLH_form_type.capitalize() }
-  % if MLH_instructions_included:
-   and Instructions 
-  % endif
-subquestion: |
-  On the next page, there will be a list of files. The top file is a cover sheet. 
-  % if MLH_instructions_included:
-    There will also be step-by-step instructions to tell you what to do next.
-  % endif
-  % if MLH_court_forms:
-  Do not file the cover sheet 
-  % if MLH_instructions_included:
-    or instructions 
-  % endif
-  with the court. The other files are the forms you will need to file with the court. 
-  % endif
-  In some situations, there will be more than one file. You will need to download each one separately. 
-
-  % if MLH_court_forms:
-  Be sure to review all of your forms before filing them to make sure all of the information is correct.
-  % else:
-  Be sure to review your ${ MLH_form_type } to make sure all of the information is correct.
-  % endif
-continue button field: MLH_outro_download_forms
-
 
 # # # # # # # # # # # # # # Court Loader - Begin # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # Court Loader - Begin # # # # # # # # # # # # # #

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.mlhframework',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.10.1', 'docassemble.AssemblyLine>=2.27.1'],
+      install_requires=['docassemble.ALToolbox>=0.10.1', 'docassemble.AssemblyLine>=2.27.2'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/mlhframework/', package='docassemble.mlhframework'),
      )


### PR DESCRIPTION
After discussion with lawyers, decided we don't need this screen anymore.

I don't think any interviews are using this directly. The security deposit tool is using its own version and the fee wavier tool is using the outro package as a whole.