### PR TITLE
Make button bigger for any URL with "sign-in"

### DIFF
--- a/docassemble/mlhframework/data/static/mlh_framework_theme.css
+++ b/docassemble/mlhframework/data/static/mlh_framework_theme.css
@@ -214,6 +214,6 @@ footer a {
 }
 
 /* Make "Sign in" button on desktop bigger: https://github.com/mplp/docassemble-mlhframework/issues/87 */
-#danavbar-collapse a.btn-primary[href="/user/sign-in"] {
+#danavbar-collapse a.btn-primary[href*="/user/sign-in"] {
   --bs-btn-font-size: 1.125rem;
 }


### PR DESCRIPTION
Using CSS wildcard attribute selector instead of a strict equality selector. See https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors.

Fix #87, for the second time. 