### PR TITLE
Saving and navigation

### DIFF
--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -228,28 +228,32 @@ continue button field: MLH_intro_time
 if: user_logged_in()
 id: MLH intro saving answers logged in
 question: |
-  Using this tool
+  Editing and saving answers
 subquestion: |
-  <h2 class="h4">Navigation</h2>
+  <h2 class="h4">Changing an Answer</h2>
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
   Tap the {green underlined words} on any screen for a definition or more information.   
-terms:
-  green underlined words: |
-    The definition or information appears when you tap the green underlined words.
   
   <h2 class="h4">Saving Your Work</h2>
   You are already signed in; just tap the **${MLH_continue_button_label}** button to save your progress. 
   
   To go back to saved answers, go to the menu at the top of the screen and select “My Forms.”
+  
+terms:
+  green underlined words: |
+    The definition or information appears when you tap the green underlined words.
 continue button field: MLH_intro_navigate_save
 ---
 if: not user_logged_in()
 id: MLH intro saving answers logged out
 question: |
-  Using this tool
+  Editing and saving answers
 subquestion: |
-  <h2 class="h4">Navigation</h2>
+  <h2 class="h4">Changing an Answer</h2>
+    If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
+
+  Tap the {green underlined words} on any screen for a definition or more information.   
   
   <h2 class="h4">Saving Your Work</h2>
   You can save your work at any time by signing in or signing up for an account.
@@ -261,6 +265,9 @@ subquestion: |
   **menu at the top of the screen** and tap "Sign in or sign up to save answers".
   
   To go back to saved answers, make sure you are logged in. Then go to the menu at the top of the screen and select “My Forms.”
+terms:
+  green underlined words: |
+    The definition or information appears when you tap the green underlined words.
 continue button field: MLH_intro_navigate_save
 
   ############## delete below after live interviews updated ############

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -260,11 +260,11 @@ subquestion: |
   <h2 class="h5">Saving Your Work</h2>
   Save your work by signing in or signing up for an account.
 
-  Below the **Continue** button, tap "Sign in" if you have an account or "Sign up" to make one. You can also go to the
+  Tap the "Sign in" or "Sign up" link below the **Continue** button. Or go to the
   % if device().is_mobile:
   :bars:
   % endif
-  **menu at the top of the screen** and tap "Sign in or sign up to save answers".
+  **menu** at the top of the screen and tap "Sign in or sign up to save answers".
   
   To go back to a saved form, make sure you are logged in. Then go to the menu at the top of the screen and select “My Forms.”
 terms:

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -230,13 +230,13 @@ id: MLH intro saving answers logged in
 question: |
   Using this tool
 subquestion: |
-  <h2 class="h6">Changing an Answer</h2>
+  <h2 class="h5">Changing an Answer</h2>
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
-  <h2 class="h6">Help Text</h2>
+  <h2 class="h5">Help Text</h2>
   Tap {green underlined words} for a definition or more information.   
   
-  <h2 class="h6">Saving Your Work</h2>
+  <h2 class="h5">Saving Your Work</h2>
   You are already signed in. Just tap the **${MLH_continue_button_label}** button to save your progress. 
   
   Go to the menu at the top of the screen and select “My Forms” to go back to a saved form.
@@ -251,13 +251,13 @@ id: MLH intro saving answers logged out
 question: |
   Using this tool
 subquestion: |
-  <h2 class="h6">Changing an Answer</h2>
+  <h2 class="h5">Changing an Answer</h2>
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
-  <h2 class="h6">Help Text</h2>
+  <h2 class="h5">Help Text</h2>
   Tap {green underlined words} for a definition or more information.   
   
-  <h2 class="h6">Saving Your Work</h2>
+  <h2 class="h5">Saving Your Work</h2>
   Save your work by signing in or signing up for an account.
 
   Below the **Continue** button, tap "Sign in" if you have an account or "Sign up" to make one. You can also go to the

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -228,18 +228,14 @@ question: "Navigation"
 subquestion: |
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
-  Tap the {green words} in any screen for a definition or more information.
-
-  You can also tap an underlined link with a green triangle next to it to see more information.
-
-  ${ collapse_template(collapsible_info_template) }
+  Tap the {green underlined words} in any screen for a definition or more information. You can also tap an ${ collapse_template(collapsible_info_template) } to see more information.
 terms:
-  green words: |
-    Green words are legal terms or a short way of referring to something that needs more explanation. The definition or explanation pops up when you tap the green words.
+  green underlined words: |
+    The definition or explanation pops up when you tap the green underlined words.
 continue button field: MLH_intro_navigation
 ---
 template: collapsible_info_template
-subject: Tap here to see more information
+subject: underlined link with a green triangle next to it
 content: |
   You can find more information or definitions by tapping on these links.
 ---

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -231,7 +231,7 @@ subquestion: |
   Tap the {green underlined words} on any screen for a definition or more information.   
 terms:
   green underlined words: |
-    The definition or explanation pops up when you tap the green underlined words.
+    The definition or information appears when you tap the green underlined words.
 continue button field: MLH_intro_navigation
 ---
 if: user_logged_in()

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -232,15 +232,14 @@ question: |
 subquestion: |
   <h2 class="h5">Changing an Answer</h2>
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
-
-  <h2 class="h5">Help Text</h2>
-  Tap {green underlined words} for a definition or more information.   
   
   <h2 class="h5">Saving Your Work</h2>
   You are already signed in. Just tap the **${MLH_continue_button_label}** button to save your progress. 
   
   Go to the menu at the top of the screen and select “My Forms” to go back to a saved form.
   
+  <h2 class="h5">Help Text</h2>
+  Tap {green underlined words} for a definition or more information.   
 terms:
   green underlined words: |
     More information appears when you tap the green underlined words.
@@ -253,20 +252,18 @@ question: |
 subquestion: |
   <h2 class="h5">Changing an Answer</h2>
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
-
-  <h2 class="h5">Help Text</h2>
-  Tap {green underlined words} for a definition or more information.   
   
   <h2 class="h5">Saving Your Work</h2>
-  Save your work by signing in or signing up for an account.
-
-  Tap the "Sign in" or "Sign up" link below the **Continue** button. Or go to the
+  Save your work by signing in or signing up for an account. Tap the "Sign in" or "Sign up" link below the **Continue** button. Or go to the
   % if device().is_mobile:
   :bars:
   % endif
   **menu** at the top of the screen and tap "Sign in or sign up to save answers".
   
   To go back to a saved form, make sure you are logged in. Then go to the menu at the top of the screen and select “My Forms.”
+  
+  <h2 class="h5">Help Text</h2>
+  Tap {green underlined words} for a definition or more information. 
 terms:
   green underlined words: |
     More information appears when you tap the green underlined words.

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -254,13 +254,13 @@ subquestion: |
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
   
   <h2 class="h5">Saving Your Work</h2>
-  Save your work by signing in or signing up for an account. Tap the "Sign in" or "Sign up" link below the **Continue** button. Or go to the
+  To save your work, sign in or sign up for an account. Tap the "Sign in" or "Sign up" link below the **Continue** button. Or go to the
   % if device().is_mobile:
   :bars:
   % endif
   **menu** at the top of the screen and tap "Sign in or sign up to save answers".
   
-  To go back to a saved form, make sure you are logged in. Then go to the menu at the top of the screen and select “My Forms.”
+  To go back to a saved form, log in. Then go to the menu at the top of the screen and select “My Forms.”
   
   <h2 class="h5">Help Text</h2>
   Tap {green underlined words} for a definition or more information. 

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -228,7 +228,7 @@ question: "Navigation"
 subquestion: |
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
-  Tap the {green underlined words} in any screen for a definition or more information.   
+  Tap the {green underlined words} on any screen for a definition or more information.   
 terms:
   green underlined words: |
     The definition or explanation pops up when you tap the green underlined words.

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -230,7 +230,13 @@ id: MLH intro saving answers logged in
 question: |
   Using this tool
 subquestion: |
-  ${ display_template(MLH_nav_saving_part_one) }
+  <h2 class="h5">Changing an Answer</h2>
+  If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
+
+  <h2 class="h5">Help Text</h2>
+  Tap {green underlined words} for a definition or more information.   
+  
+  <h2 class="h5">Saving Your Work</h2>
   You are already signed in. Just tap the **${MLH_continue_button_label}** button to save your progress. 
   
   Go to the menu at the top of the screen and select “My Forms” to go back to a saved form.
@@ -245,7 +251,13 @@ id: MLH intro saving answers logged out
 question: |
   Using this tool
 subquestion: |
-  ${ display_template(MLH_nav_saving_part_one) }
+  <h2 class="h5">Changing an Answer</h2>
+  If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
+
+  <h2 class="h5">Help Text</h2>
+  Tap {green underlined words} for a definition or more information.   
+  
+  <h2 class="h5">Saving Your Work</h2>
   Save your work by signing in or signing up for an account.
 
   Below the **Continue** button, tap "Sign in" if you have an account or "Sign up" to make one. You can also go to the
@@ -260,18 +272,7 @@ terms:
     More information appears when you tap the green underlined words.
 continue button field: MLH_intro_navigate_save
 ---
-template: MLH_nav_saving_part_one
-subject: ""
-content: |
-  <h2 class="h4">Changing an Answer</h2>
-  If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
-
-  <h2 class="h4">Help Text</h2>
-  Tap {green underlined words} for a definition or more information.   
-  
-  <h2 class="h4">Saving Your Work</h2>
   ############## delete below after live interviews updated ############
----
 id: MLH intro navigation
 question: "Navigation"
 subquestion: |

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -230,20 +230,20 @@ id: MLH intro saving answers logged in
 question: |
   Using this tool
 subquestion: |
-  <h2 class="h3">Changing an Answer</h2>
+  <h2 class="h4">Changing an Answer</h2>
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
-  <h2 class="h3">Help Text</h2>
-  You can tap {green underlined words} for a definition or more information.   
+  <h2 class="h4">Help Text</h2>
+  Tap {green underlined words} for a definition or more information.   
   
-  <h2 class="h3">Saving Your Work</h2>
+  <h2 class="h4">Saving Your Work</h2>
   You are already signed in. Just tap the **${MLH_continue_button_label}** button to save your progress. 
   
-  To find saved answers, go to the menu at the top of the screen and select “My Forms.”
+  Go to the menu at the top of the screen and select “My Forms” to go back to a saved form.
   
 terms:
   green underlined words: |
-    The definition or information appears when you tap the green underlined words.
+    More information appears when you tap the green underlined words.
 continue button field: MLH_intro_navigate_save
 ---
 if: not user_logged_in()
@@ -251,13 +251,13 @@ id: MLH intro saving answers logged out
 question: |
   Using this tool
 subquestion: |
-  <h2 class="h3">Changing an Answer</h2>
+  <h2 class="h4">Changing an Answer</h2>
     If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
-  <h2 class="h3">Help Text</h2>
-  You can tap {green underlined words} for a definition or more information.   
+  <h2 class="h4">Help Text</h2>
+  Tap {green underlined words} for a definition or more information.   
   
-  <h2 class="h3">Saving Your Work</h2>
+  <h2 class="h4">Saving Your Work</h2>
   Save your work by signing in or signing up for an account.
 
   Below the **Continue** button, tap "Sign in" if you have an account or "Sign up" to make one. You can also go to the
@@ -266,10 +266,10 @@ subquestion: |
   % endif
   **menu at the top of the screen** and tap "Sign in or sign up to save answers".
   
-  To find saved answers, make sure you are logged in. Then go to the menu at the top of the screen and select “My Forms.”
+  To go back to a saved form, make sure you are logged in. Then go to the menu at the top of the screen and select “My Forms.”
 terms:
   green underlined words: |
-    The definition or information appears when you tap the green underlined words.
+    More information appears when you tap the green underlined words.
 continue button field: MLH_intro_navigate_save
 
   ############## delete below after live interviews updated ############

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -230,13 +230,7 @@ id: MLH intro saving answers logged in
 question: |
   Using this tool
 subquestion: |
-  <h2 class="h4">Changing an Answer</h2>
-  If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
-
-  <h2 class="h4">Help Text</h2>
-  Tap {green underlined words} for a definition or more information.   
-  
-  <h2 class="h4">Saving Your Work</h2>
+  ${ display_template(MLH_nav_saving_part_one) }
   You are already signed in. Just tap the **${MLH_continue_button_label}** button to save your progress. 
   
   Go to the menu at the top of the screen and select “My Forms” to go back to a saved form.
@@ -251,13 +245,7 @@ id: MLH intro saving answers logged out
 question: |
   Using this tool
 subquestion: |
-  <h2 class="h4">Changing an Answer</h2>
-    If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
-
-  <h2 class="h4">Help Text</h2>
-  Tap {green underlined words} for a definition or more information.   
-  
-  <h2 class="h4">Saving Your Work</h2>
+  ${ display_template(MLH_nav_saving_part_one) }
   Save your work by signing in or signing up for an account.
 
   Below the **Continue** button, tap "Sign in" if you have an account or "Sign up" to make one. You can also go to the
@@ -271,7 +259,17 @@ terms:
   green underlined words: |
     More information appears when you tap the green underlined words.
 continue button field: MLH_intro_navigate_save
+---
+template: MLH_nav_saving_part_one
+subject: ""
+content: |
+  <h2 class="h4">Changing an Answer</h2>
+  If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
+  <h2 class="h4">Help Text</h2>
+  Tap {green underlined words} for a definition or more information.   
+  
+  <h2 class="h4">Saving Your Work</h2>
   ############## delete below after live interviews updated ############
 ---
 id: MLH intro navigation

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -228,17 +228,18 @@ continue button field: MLH_intro_time
 if: user_logged_in()
 id: MLH intro saving answers logged in
 question: |
-  Editing and saving answers
+  Using this tool
 subquestion: |
-  <h2 class="h4">Changing an Answer</h2>
+  <h2 class="h3">Changing an Answer</h2>
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
-  Tap the {green underlined words} on any screen for a definition or more information.   
+  <h2 class="h3">Help Text</h2>
+  You can tap {green underlined words} for a definition or more information.   
   
-  <h2 class="h4">Saving Your Work</h2>
-  You are already signed in; just tap the **${MLH_continue_button_label}** button to save your progress. 
+  <h2 class="h3">Saving Your Work</h2>
+  You are already signed in. Just tap the **${MLH_continue_button_label}** button to save your progress. 
   
-  To go back to saved answers, go to the menu at the top of the screen and select “My Forms.”
+  To find saved answers, go to the menu at the top of the screen and select “My Forms.”
   
 terms:
   green underlined words: |
@@ -248,15 +249,16 @@ continue button field: MLH_intro_navigate_save
 if: not user_logged_in()
 id: MLH intro saving answers logged out
 question: |
-  Editing and saving answers
+  Using this tool
 subquestion: |
-  <h2 class="h4">Changing an Answer</h2>
+  <h2 class="h3">Changing an Answer</h2>
     If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
-  Tap the {green underlined words} on any screen for a definition or more information.   
+  <h2 class="h3">Help Text</h2>
+  You can tap {green underlined words} for a definition or more information.   
   
-  <h2 class="h4">Saving Your Work</h2>
-  You can save your work at any time by signing in or signing up for an account.
+  <h2 class="h3">Saving Your Work</h2>
+  Save your work by signing in or signing up for an account.
 
   Below the **Continue** button, tap "Sign in" if you have an account or "Sign up" to make one. You can also go to the
   % if device().is_mobile:
@@ -264,7 +266,7 @@ subquestion: |
   % endif
   **menu at the top of the screen** and tap "Sign in or sign up to save answers".
   
-  To go back to saved answers, make sure you are logged in. Then go to the menu at the top of the screen and select “My Forms.”
+  To find saved answers, make sure you are logged in. Then go to the menu at the top of the screen and select “My Forms.”
 terms:
   green underlined words: |
     The definition or information appears when you tap the green underlined words.

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -230,13 +230,13 @@ id: MLH intro saving answers logged in
 question: |
   Using this tool
 subquestion: |
-  <h2 class="h5">Changing an Answer</h2>
+  <h2 class="h6">Changing an Answer</h2>
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
-  <h2 class="h5">Help Text</h2>
+  <h2 class="h6">Help Text</h2>
   Tap {green underlined words} for a definition or more information.   
   
-  <h2 class="h5">Saving Your Work</h2>
+  <h2 class="h6">Saving Your Work</h2>
   You are already signed in. Just tap the **${MLH_continue_button_label}** button to save your progress. 
   
   Go to the menu at the top of the screen and select “My Forms” to go back to a saved form.
@@ -251,13 +251,13 @@ id: MLH intro saving answers logged out
 question: |
   Using this tool
 subquestion: |
-  <h2 class="h5">Changing an Answer</h2>
+  <h2 class="h6">Changing an Answer</h2>
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
-  <h2 class="h5">Help Text</h2>
+  <h2 class="h6">Help Text</h2>
   Tap {green underlined words} for a definition or more information.   
   
-  <h2 class="h5">Saving Your Work</h2>
+  <h2 class="h6">Saving Your Work</h2>
   Save your work by signing in or signing up for an account.
 
   Below the **Continue** button, tap "Sign in" if you have an account or "Sign up" to make one. You can also go to the

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -159,8 +159,11 @@ code: |
 code: |
   MLH_intro_landing
   MLH_agree_terms
+  ##### delete below after live interviews updated ######
   MLH_intro_navigation
   MLH_intro_saving_answers
+  #### delete above after live interviews updated ######
+  MLH_intro_navigate_save
   MLH_intro_time
   if MLH_intro_agree_no_pii == False:
     MLH_intro_agree_no_pii_exit
@@ -206,7 +209,7 @@ validation code: |
     validation_error("You must accept the Terms of Use and Privacy Policy to continue.", field="acknowledged_information_use")
 ---
 id: MLH intro time
-question: "Using this Tool"
+question: "Answer the questions to get your ${ MLH_form_type }"
 subquestion: |
   It will probably take about **${ MLH_time_min } to ${ MLH_time_max } minutes** to answer all the questions.
   % if MLH_materials_included:
@@ -221,7 +224,46 @@ subquestion: |
     You will also get instructions for what to do next with your ${ MLH_form_type }.
   % endif
 continue button field: MLH_intro_time
+---
+if: user_logged_in()
+id: MLH intro saving answers logged in
+question: |
+  Using this tool
+subquestion: |
+  <h2 class="h4">Navigation</h2>
+  If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
+  Tap the {green underlined words} on any screen for a definition or more information.   
+terms:
+  green underlined words: |
+    The definition or information appears when you tap the green underlined words.
+  
+  <h2 class="h4">Saving Your Work</h2>
+  You are already signed in; just tap the **${MLH_continue_button_label}** button to save your progress. 
+  
+  To go back to saved answers, go to the menu at the top of the screen and select “My Forms.”
+continue button field: MLH_intro_navigate_save
+---
+if: not user_logged_in()
+id: MLH intro saving answers logged out
+question: |
+  Using this tool
+subquestion: |
+  <h2 class="h4">Navigation</h2>
+  
+  <h2 class="h4">Saving Your Work</h2>
+  You can save your work at any time by signing in or signing up for an account.
+
+  Below the **Continue** button, tap "Sign in" if you have an account or "Sign up" to make one. You can also go to the
+  % if device().is_mobile:
+  :bars:
+  % endif
+  **menu at the top of the screen** and tap "Sign in or sign up to save answers".
+  
+  To go back to saved answers, make sure you are logged in. Then go to the menu at the top of the screen and select “My Forms.”
+continue button field: MLH_intro_navigate_save
+
+  ############## delete below after live interviews updated ############
 ---
 id: MLH intro navigation
 question: "Navigation"
@@ -259,6 +301,8 @@ subquestion: |
   
   To go back to saved answers, make sure you are logged in. Then go to the menu at the top of the screen and select “My Forms.”
 continue button field: MLH_intro_saving_answers
+  ############## delete above after live interviews updated ###########
+
 ---
 id: MLH intro PII
 question: Private Information

--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -228,16 +228,11 @@ question: "Navigation"
 subquestion: |
   If you make a mistake, you can use the **${ MLH_back_button_label }** button below to go back. You can also see and edit earlier answers by tapping the "✎ Review / Edit" link.
 
-  Tap the {green underlined words} in any screen for a definition or more information. You can also tap an ${ collapse_template(collapsible_info_template) } to see more information.
+  Tap the {green underlined words} in any screen for a definition or more information.   
 terms:
   green underlined words: |
     The definition or explanation pops up when you tap the green underlined words.
 continue button field: MLH_intro_navigation
----
-template: collapsible_info_template
-subject: underlined link with a green triangle next to it
-content: |
-  You can find more information or definitions by tapping on these links.
 ---
 if: user_logged_in()
 id: MLH intro saving answers logged in

--- a/docassemble/mlhframework/data/static/mlh_framework_theme.css
+++ b/docassemble/mlhframework/data/static/mlh_framework_theme.css
@@ -24,44 +24,6 @@
   padding: 3px;
 }
 
-.da-subquestion h2 {
-  font-size: calc(1.28rem + 0.5vw);
-}
-
-.da-subquestion h3 {
-  font-size: calc(1.27rem + 0.3vw);
-}
-
-.da-subquestion h4 {
-  font-size: calc(1.26rem + 0.2vw);
-}
-
-.da-subquestion h4 {
-  font-size: 1.25rem;
-}
-
-@media (min-width: 1200px) {
-  .da-subquestion h2 {
-    font-size: 1.62rem;
-  }
-
-  .da-subquestion h3 {
-    font-size: 1.41rem;
-  }
-
-  .da-subquestion h4 {
-    font-size: 1.31rem;
-  }
-
-  .da-subquestion h5 {
-    font-size: 1.25rem;
-  }
-
-  .da-subquestion h6 {
-    font-size: 1.20rem;
-  }
-}
-
 /* Make the nav bar contents (title and logo) smaller on narrow screens, and
    clip contents instead of letting them push menu button to the next line */
 @media only screen and (max-width: 800px) {


### PR DESCRIPTION
Combine saving and navigation screens into one to reduce number of intro screens; and reduce word count throughout.

- Leaving the old version intact for now so that we don't break the live interview when we update.
- deleted custom header sizing we had added because it wasn't giving enough differentiation between header levels
- I also think the "Using this tool" name would now fit better for this screen, so I stole it and renamed MLH_intro_time.