### PR TITLE
try out survey embed

### DIFF
--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -19,6 +19,7 @@ features:
   progress bar: True
   progress bar method: stepped
   javascript:
+    - survey_monkey_script.js #referencing files in individual interviews
     - insert_survey_monkey_script.js
 ---
 objects:
@@ -495,7 +496,7 @@ subquestion: |
   
   <h2 class="h3">Take our quick survey!</h2>
   Answer below or [open the survey in a new tab](${ survey_link_url_only }).
-  ${ survey_embed_script }
+  <div id="survey_monkey1"></div>
 progress: 100
 # <div id="survey_monkey1"></div>  #we can switch out ${ survey_embed_script } with this once all tools have the necessary JS to use new method
 ---


### PR DESCRIPTION
tried with both js files (framework and interview ones) included in "features" in framework:
---did not work, appears we need to include `survey_monkey_script.js` in individual interviews

Also will need to consider if we like the survey where it is or prefer under the "under" button like in food stamp tool. In food stamp tool was especially important because "Undo" button was the only way to go back. 