### PR TITLE
fix: define limited set of al_name_suffixes as override to assemblyline defaults

### DIFF
--- a/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
+++ b/docassemble/mlhframework/data/questions/mlh_interview_framework.yml
@@ -114,6 +114,20 @@ code: |
   snapshot_dv_question = False       # override if interview asks whether there's domestic violence
   snapshot_dv_present = "unknown"    # if interview asks about DV, set True if DV present, False if not
 ---
+# override the AL default
+variable name: al_name_suffixes
+data:
+  - Jr
+  - Junior
+  - Sr
+  - Senior
+  - I
+  - II
+  - III
+  - IV
+  - V
+  - VI
+---
 ######
 ---
 # default welcome info; keep relatively short. If lots of preconditions/warnings, make separate screen
@@ -1131,3 +1145,4 @@ content: |
   Your ${ x.document_label } document is attached.
   
   Visit ${ resource_page_link } to learn more.
+---


### PR DESCRIPTION
This PR provides a definition of `al_name_suffixes` lower than the AssemblyLine default, so docassemble will use this list instead.

Tested and working in the Statutory Will. Should work anywhere else that doesn't manually override the suffix list.